### PR TITLE
add optparse to CRAN packages

### DIFF
--- a/01_Installation.md
+++ b/01_Installation.md
@@ -12,7 +12,7 @@ source("http://www.bioconductor.org/biocLite.R")
 biocLite("rhdf5")
 
 # packages from CRAN
-install.packages(c("shiny","svDialogs","data.table","bit64"))
+install.packages(c("shiny","svDialogs","data.table","bit64","optparse"))
 
 ```
 


### PR DESCRIPTION
Though not required for `poRe`, `optparse` is necessary to run the scripts for [`poRe_scripts`](https://github.com/mw55309/poRe_scripts)